### PR TITLE
pack struct IRMP_DATA, otherwise we try to read on byte too much because...

### DIFF
--- a/irmplircd.c
+++ b/irmplircd.c
@@ -50,7 +50,7 @@
 #include "hashmap.h"
 #include "mapping.h"
 
-typedef struct {
+typedef struct __attribute__ ((__packed__)) {
   uint8_t	report_id;	// report id
   uint8_t	protocol;	// protocol, i.e. NEC_PROTOCOL
   uint16_t	address;	// address


### PR DESCRIPTION
... of padding

`sizeof event` is 8 without packing, thus `read()` tries to read 8 bytes instead of 7. This is caused by a padding byte inserted after the element `flags`.