### PR TITLE
Move includes in Makefile to separate variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,8 @@ SBIN_IRMPEXEC  = irmpexec
 MAN8 = irmplircd.8
 
 CC ?= gcc
-CFLAGS ?= -Wall -g -O2 -pipe -Ic_hashmap #-DDEBUG
+CFLAGS ?= -Wall -g -O2 -pipe #-DDEBUG
+INCLUDES ?= -Ic_hashmap
 PREFIX ?= /usr/local
 INSTALL ?= install
 STRIP ?= strip
@@ -14,22 +15,22 @@ MANDIR ?= $(SHAREDIR)/man
 all: $(SBIN_IRMPLIRCD) $(SBIN_IRMPEXEC)
 
 irmplircd.o: irmplircd.c debug.h
-	$(CC) $(CFLAGS) -c $<
+	$(CC) $(CFLAGS) $(INCLUDES) -c $<
 
 irmpexec.o: irmpexec.c debug.h
-	$(CC) $(CFLAGS) -c $<
+	$(CC) $(CFLAGS) $(INCLUDES) -c $<
 
 mapping.o: mapping.c mapping.h debug.h
-	$(CC) $(CFLAGS) -c $<
+	$(CC) $(CFLAGS) $(INCLUDES) -c $<
 
 hashmap.o: c_hashmap/hashmap.c c_hashmap/hashmap.h
-	$(CC) $(CFLAGS) -c $<
+	$(CC) $(CFLAGS) $(INCLUDES) -c $<
 
 irmplircd: irmplircd.o mapping.o c_hashmap/hashmap.o
-	$(CC) $(CFLAGS) -o $@ irmplircd.o mapping.o c_hashmap/hashmap.o
+	$(CC) $(CFLAGS) $(INCLUDES) -o $@ irmplircd.o mapping.o c_hashmap/hashmap.o
 
 irmpexec: irmpexec.o mapping.o c_hashmap/hashmap.o
-	$(CC) $(CFLAGS) -o $@ irmpexec.o mapping.o c_hashmap/hashmap.o
+	$(CC) $(CFLAGS) $(INCLUDES) -o $@ irmpexec.o mapping.o c_hashmap/hashmap.o
 
 install: install-sbin install-man
 


### PR DESCRIPTION
When packaging for distributions the build systems often globally override CFLAGS with the distribution standard.

With your current Makefile this means that the "-Ic_hashmap" is missing and so compile fails. I've separated this into an "INCLUDES"-Variable.

It would also be possible to fix this in the C files by prefixing the include path with "c_hashmap". In this case the "-Ic_hashmap" is no longer needed at all. Please tell me if you prefer this solution, so I can create another pull request.