### PR TITLE
Skip empty lines and allow comments in mapping tables

### DIFF
--- a/irmplircd.8
+++ b/irmplircd.8
@@ -63,6 +63,7 @@ The default is nobody.
 Provides the path to a file containing a mapping between input event key names and the commands which
 should be reported via lirc. The files should contain lines of the form
 .Pa KEY_FOO = bar .
+The pound sign ('#') is used to indicate a comment.
 This is useful for backward compatibility.
 The default is not to use a translation table.
 .It Ar device

--- a/irmplircd.8
+++ b/irmplircd.8
@@ -63,7 +63,7 @@ The default is nobody.
 Provides the path to a file containing a mapping between input event key names and the commands which
 should be reported via lirc. The files should contain lines of the form
 .Pa KEY_FOO = bar .
-The pound sign ('#') is used to indicate a comment.
+Lines starting with the pound sign ('#') are ignored.
 This is useful for backward compatibility.
 The default is not to use a translation table.
 .It Ar device

--- a/mapping.c
+++ b/mapping.c
@@ -62,6 +62,10 @@ bool parse_translation_table(const char *path, map_t mymap) {
 	}
 
 	while(getline(&line, &line_size, table) >= 0) {
+		// Skip empty lines and lines starting with "#"
+		if (strcspn(line, "\n\r#") == 0)
+			continue;
+
 		len = sscanf(line, "%99s %99s", key, value);
 		if(len != 2) {
 			syslog(LOG_ERR, "line ignored: %s\n", line);


### PR DESCRIPTION
If I try to separate groups of lines using empty lines, I get error messages in syslog.
Comments, to add small notes, are not possible at all.

The following small change skips completely empty lines and lines starting with the "#" sign.