### PR TITLE
allow values(commands) containing white space

### DIFF
--- a/mapping.c
+++ b/mapping.c
@@ -66,7 +66,7 @@ bool parse_translation_table(const char *path, map_t mymap) {
 		if (strcspn(line, "\n\r#") == 0)
 			continue;
 
-		len = sscanf(line, "%99s %99s", key, value);
+		len = sscanf(line, "%99s %99[^\n]", key, value);
 		if(len != 2) {
 			syslog(LOG_ERR, "line ignored: %s\n", line);
 			continue;


### PR DESCRIPTION
As already mentioned by fluhri in July 2012 [1], for commands with whitespaces to work a patch is needed.
fluhri's suggestion was not perfect, though.
The reference page for the ISO C standard [2] explains, how this patch works. Instead of stopping at the next whitespace now the line is being read till the end.
[1] https://www.vdr-portal.de/forum/index.php?thread/108165-irmplircd-f%C3%BCr-usb-ir-remote-receiver-based-on-irmp/&postID=1085624#post1085624
[2] https://pubs.opengroup.org/onlinepubs/9699919799/functions/fscanf.html, section [